### PR TITLE
Small improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.quanqi'
-version '0.2.0'
+version '0.2.1'
 
 apply plugin: 'groovy'
 apply plugin: 'maven'

--- a/src/main/groovy/org/quanqi/gradle/android/upload/AndroidMavenPublishPlugin.groovy
+++ b/src/main/groovy/org/quanqi/gradle/android/upload/AndroidMavenPublishPlugin.groovy
@@ -42,7 +42,6 @@ class AndroidMavenPublishPlugin implements Plugin<Project> {
             task.group = GROUP_NAME
             task.description = "publish ${variant.name} to maven"
             task.variant = variant
-            task.dependsOn(variant.assemble)
             uploadAllTask.dependsOn(task)
         }
     }

--- a/src/main/groovy/org/quanqi/gradle/android/upload/AndroidMavenPublishTask.groovy
+++ b/src/main/groovy/org/quanqi/gradle/android/upload/AndroidMavenPublishTask.groovy
@@ -1,14 +1,21 @@
 package org.quanqi.gradle.android.upload
 
 import com.android.build.gradle.api.ApplicationVariant
+import com.squareup.okhttp.OkHttpClient
 import org.gradle.api.DefaultTask
-import org.gradle.api.ProjectConfigurationException
+import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
+
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
 
 /**
  * Created by cindy on 12/18/15.
  */
 class AndroidMavenPublishTask extends DefaultTask {
+
+    static Logger sLogger = Logger.getLogger(AndroidMavenPublishTask.class.getName())
+    static OkHttpClient sHttpClient = null
 
     ApplicationVariant variant
     AndroidMavenPublishExtension publishExtension
@@ -21,12 +28,15 @@ class AndroidMavenPublishTask extends DefaultTask {
     @TaskAction
     def upload() {
         publishExtension = project."${AndroidMavenPublishExtension.NAME}"
+        if (sHttpClient == null) {
+            sHttpClient = createHttpClient()
+        }
         uploadApk()
         uploadMapping()
     }
 
     def uploadApk() {
-        MavenDeploy deploy = create()
+        MavenDeploy deploy = createBasicDeployConfiguration()
         deploy.classifier = variant.name
         deploy.extension = 'apk'
         deploy.packaging = 'apk'
@@ -36,27 +46,42 @@ class AndroidMavenPublishTask extends DefaultTask {
                 return true
             }
         }
-        deploy.deploy()
+
+        if (!deploy.file) {
+            throw new GradleException(String.format("could not determine APK output file for variant %s", variant.name))
+        }
+
+        if (!deploy.file.exists()) {
+            throw new GradleException(String.format("output file %1$s for variant %2$s does not exist", deploy.file, variant.name))
+        }
+
+        deploy.deploy(sLogger, sHttpClient)
     }
 
     def uploadMapping() {
-        MavenDeploy deploy = create()
+        if (!variant.mappingFile.exists()) {
+            sLogger.info("skipping non-existing mapping file for variant " + variant.name)
+            return
+        }
+
+        MavenDeploy deploy = createBasicDeployConfiguration()
         deploy.classifier = "${variant.name}-mapping"
         deploy.extension = 'txt'
         deploy.packaging = 'txt'
         deploy.file = variant.mappingFile
-        deploy.deploy()
+        deploy.deploy(sLogger, sHttpClient)
     }
 
-    MavenDeploy create() {
+    MavenDeploy createBasicDeployConfiguration() {
         MavenDeploy mavenDeploy = new MavenDeploy()
-        if (publishExtension.groupId != null) {
+        if (publishExtension.groupId) {
             mavenDeploy.group = publishExtension.groupId
-        } else if (project.group != null) {
+        } else if (project.group) {
             mavenDeploy.group = project.group
         } else {
-            throw new ProjectConfigurationException("missing group", null);
+            throw new GradleException("no `groupId' or `project.group' configured or empty")
         }
+
         if (publishExtension.artifactId != null) {
             mavenDeploy.artifact = publishExtension.artifactId
         } else {
@@ -64,12 +89,20 @@ class AndroidMavenPublishTask extends DefaultTask {
         }
 
         mavenDeploy.url = publishExtension.url
+        if (!publishExtension.repository) {
+            throw new GradleException("no `repository' to upload to configured or empty")
+        }
         mavenDeploy.repository = publishExtension.repository
         mavenDeploy.user = publishExtension.user
         mavenDeploy.password = publishExtension.password
         mavenDeploy.version = variant.versionName
-        mavenDeploy.packaging = 'apk'
-        mavenDeploy.extension = 'apk'
         return mavenDeploy
+    }
+
+    static OkHttpClient createHttpClient() {
+        OkHttpClient httpClient = new OkHttpClient();
+        httpClient.setConnectTimeout(10, TimeUnit.SECONDS)
+        httpClient.setReadTimeout(60, TimeUnit.SECONDS)
+        return httpClient
     }
 }

--- a/src/main/groovy/org/quanqi/gradle/android/upload/AndroidMavenPublishTask.groovy
+++ b/src/main/groovy/org/quanqi/gradle/android/upload/AndroidMavenPublishTask.groovy
@@ -52,14 +52,14 @@ class AndroidMavenPublishTask extends DefaultTask {
         }
 
         if (!deploy.file.exists()) {
-            throw new GradleException(String.format("output file %1$s for variant %2$s does not exist", deploy.file, variant.name))
+            throw new GradleException(String.format('output file %1$s for variant %2$s does not exist', deploy.file, variant.name))
         }
 
         deploy.deploy(sLogger, sHttpClient)
     }
 
     def uploadMapping() {
-        if (!variant.mappingFile.exists()) {
+        if (!variant.mappingFile || !variant.mappingFile.exists()) {
             sLogger.info("skipping non-existing mapping file for variant " + variant.name)
             return
         }

--- a/src/main/groovy/org/quanqi/gradle/android/upload/MavenDeploy.groovy
+++ b/src/main/groovy/org/quanqi/gradle/android/upload/MavenDeploy.groovy
@@ -70,8 +70,8 @@ class MavenDeploy {
                 .addFormDataPart('p', packaging)
                 .addFormDataPart('e', extension)
                 .addFormDataPart('c', classifier)
-                .addFormDataPart('file', file.name, RequestBody.create(MediaType.parse("maven/$packaging"), file))
                 .addFormDataPart('hasPom', 'false')
+                .addFormDataPart('file', file.name, RequestBody.create(MediaType.parse("maven/$packaging"), file))
 
         Response response
         try {


### PR DESCRIPTION
This PR changes the following things:
- no more resource leakage because OkHttps `Response.body()` was not closed
- plugin errors out properly if the remote server returns with an response code >= `400`
- the OkHttp instance is shared amongst all uploads, so we do not run out of handles
- there exist now checks whether the particular file that should be uploaded exists at all (and the mapping file upload is made optional)
- not only null'd, but also empty `group` / `groupIds` now lead to an exception; additionally we also check for the existance of a repository
- the basic auth was made optional
- basic logging was introduced (visible when ran with `--info`)

This could all be made much more cleaner, but my time was limited. I also figured out that one cannot upload `-SNAPSHOT` builds via the REST interface this plugin targets (apparently because of https://issues.sonatype.org/browse/NEXUS-3384), but I wonder what the "official" maven plugin uses instead, because uploads to snapshot repos work there. It would probably a good idea to mention this in the README.
Also, it took me some time to figure out that the `url` parameter is actually my nexus URL appended by the fixed REST API URL `/service/local/artifact/maven/content` - is this only valid for Nexus repos? This also deserves a line in the README... :)
